### PR TITLE
Add support for STS regional endpoints

### DIFF
--- a/sagemaker_ssh_helper/wrapper.py
+++ b/sagemaker_ssh_helper/wrapper.py
@@ -69,7 +69,9 @@ class SSHEnvironmentWrapper(ABC):
 
     def _augment_env(self, env):
         if self.local_user_id is None:
-            caller_id = boto3.client('sts').get_caller_identity()
+            region = self.sagemaker_session.boto_region_name
+            endpoint_url = "https://sts.{}.amazonaws.com".format(region)
+            caller_id = boto3.client("sts", region_name=region, endpoint_url=endpoint_url).get_caller_identity()
             user_id = caller_id.get('UserId')
         else:
             user_id = self.local_user_id


### PR DESCRIPTION
*Issue #32 :*

*Description of changes:*

By default sts client uses global endpoint which is "https://sts.amazonaws.com" while initializing using boto3. This PR contains changes to add  regional parameter and endpoint url based on the region for initializing STS client using boto3. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
