### PR TITLE
Update doc to match console ui for tier settings

### DIFF
--- a/IAM_SSM_Setup.md
+++ b/IAM_SSM_Setup.md
@@ -73,7 +73,7 @@ To understand more what CDK bootstrapping does, see [the documentation](https://
 
 a. Enable advanced instances tier to use managed instances (such as SageMaker managed containers): 
    
-Go to AWS Console -> Systems Manager -> Fleet Manager -> Account management -> Instance tier settings -> Change account setting -> Confirm change from Standard-Tier to Advanced-Tier.
+Go to AWS Console -> Systems Manager -> Fleet Manager -> Settings -> Change instance tier settings -> Confirm change from Standard-Tier to Advanced-Tier.
 
 Repeat for each AWS Region that you plan to use with SageMaker SSH Helper.
 


### PR DESCRIPTION
*Description of changes:*
I believe the process of upgrading instance tier changed a little bit in console, I've updated the documentation to reflect it. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
![Screenshot from 2024-01-17 12-55-09](https://github.com/aws-samples/sagemaker-ssh-helper/assets/2440125/def41768-6fa7-434e-a3ff-5c4e3dc3217d)
![Screenshot from 2024-01-17 12-54-38](https://github.com/aws-samples/sagemaker-ssh-helper/assets/2440125/a403780a-e2be-444d-8d58-c19fdb0cb1bf)
![Screenshot from 2024-01-17 14-54-08](https://github.com/aws-samples/sagemaker-ssh-helper/assets/2440125/db856bb3-d540-4362-982f-dbf72e023f21)
