### PR TITLE
Auto-populate SageMaker userId in SageMaker_SSH_IDE.ipynb

### DIFF
--- a/SageMaker_SSH_IDE.ipynb
+++ b/SageMaker_SSH_IDE.ipynb
@@ -152,7 +152,8 @@
     "tags": []
    },
    "source": [
-    "In the next cell you need to put your local user id as the parameter to `init-ssm`. It will help to tag the managed instance with your [aws:userid](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable) as the principal owner. You can find the id by running locally the `aws sts get-caller-identity` command as the value of the returned `UserId`.\n",
+    "In the next cell you configure your local user id as the parameter to `init-ssm`. It will help to tag the managed \n",
+    "instance with your [aws:userid](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable) as the principal owner. You can find the id by running locally the `aws sts get-caller-identity` command as the value of the returned `UserId`.\n",
     "\n",
     "If you already configured the id from another kernel app, leave the value as is (it will be loaded from the shared configuration file automatically)."
    ]
@@ -166,7 +167,9 @@
    "outputs": [],
    "source": [
     "%%sh\n",
-    "LOCAL_USER_ID=\"AIDACKCEVSQ6C2EXAMPLE:terry@SSO\"  # replace with your local UserId\n",
+    "LOCAL_USER_ID=$(aws sts get-caller-identity | jq -r .UserId)\n",
+    "\n",
+    "echo $LOCAL_USER_ID\n",
     "\n",
     "sm-ssh-ide set-local-user-id \"$LOCAL_USER_ID\""
    ]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

I am not sure if there is a good reason why the user has to manually populate `LOCAL_USER_ID` variable when it can be set automatically. It saves time each time one needs to rerun the notebook.

I tested this change in `ml.m5` and `ml.c5`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
