### PR TITLE
fix(64): update cdk, python runtime, and docs.

### DIFF
--- a/IAM_SSM_Setup.md
+++ b/IAM_SSM_Setup.md
@@ -34,13 +34,13 @@ pip install 'sagemaker-ssh-helper[cdk]'
 
 cdk bootstrap aws://"$ACCOUNT_ID"/"$REGION"
 
-APP="python -m sagemaker_ssh_helper.cdk.iam_ssm_app"
+APP="python3 -m sagemaker_ssh_helper.cdk.iam_ssm_app"
 
 AWS_REGION="$REGION" cdk -a "$APP" deploy SSH-IAM-SSM-Stack \
   -c sagemaker_role="$SAGEMAKER_ROLE_ARN" \
   -c user_role="$USER_ROLE_ARN"
 
-APP="python -m sagemaker_ssh_helper.cdk.advanced_tier_app"
+APP="python3 -m sagemaker_ssh_helper.cdk.advanced_tier_app"
 
 AWS_REGION="$REGION" cdk -a "$APP" deploy SSM-Advanced-Tier-Stack
 ```

--- a/sagemaker_ssh_helper/cdk/iam_ssm/iam_ssm_stack.py
+++ b/sagemaker_ssh_helper/cdk/iam_ssm/iam_ssm_stack.py
@@ -162,7 +162,7 @@ class IamSsmStack(Stack):
                         ])})
 
         triggers.TriggerFunction(self, "TrustRelationshipLambdaTrigger",
-                                 runtime=lambda_.Runtime.PYTHON_3_7,
+                                 runtime=lambda_.Runtime.PYTHON_3_9,
                                  role=role,
                                  handler="index.handler",
                                  code=lambda_.Code.from_inline(code))

--- a/sagemaker_ssh_helper/cdk/iam_ssm/ssm_advanced_tier_stack.py
+++ b/sagemaker_ssh_helper/cdk/iam_ssm/ssm_advanced_tier_stack.py
@@ -28,7 +28,7 @@ class SsmAdvancedTierStack(Stack):
                         ])})
 
         triggers.TriggerFunction(self, "SSMAdvancedTierTrigger",
-                                 runtime=lambda_.Runtime.PYTHON_3_7,
+                                 runtime=lambda_.Runtime.PYTHON_3_9,
                                  role=role,
                                  handler="index.handler",
                                  code=lambda_.Code.from_inline(code))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ required_packages = [
 
 extras = {
     "cdk": [
-        "aws-cdk-lib==2.64.0",
+        "aws-cdk-lib==2.77.0",
         "constructs>=10.0.0,<11.0.0",
     ],
     "test": [


### PR DESCRIPTION


*Issue #, if available:* 64

*Description of changes:*

Note
---
Currently, the automated cdk cloud 9 setup breaks. Reason being the python 3.7 runtime is no longer supported. In addition, when updating the runtime,
the nodejs version complaint comes up.

Therefore, this commit updates the CDK to fix nodejs 12.x problem. And the python runtimes to 3.9 to resolve the issue 64.

Also update the documentation to mention python3.
Reason being python not found error happens otherwise.

Related
---
- https://github.com/aws-samples/sagemaker-ssh-helper/issues/64

Testing
---
Tested on Cloud9 IDE. Both stack got deployed successfully. Please see PR for full logs of the script run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Logs:

```shell
Admin:~/environment $ git clone https://github.com/aws-samples/sagemaker-ssh-helper.git
Cloning into 'sagemaker-ssh-helper'...
remote: Enumerating objects: 1871, done.
remote: Counting objects: 100% (100/100), done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 1871 (delta 87), reused 84 (delta 84), pack-reused 1771 (from 1)
Receiving objects: 100% (1871/1871), 8.20 MiB | 21.87 MiB/s, done.
Resolving deltas: 100% (1333/1333), done.
Admin:~/environment $ pip install -e sagemaker_ssh_helper[cdk]
Defaulting to user installation because normal site-packages is not writeable
ERROR: sagemaker_ssh_helper[cdk] is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+fij
Admin:~/environment $ ls
README.md  sagemaker-ssh-helper
Admin:~/environment $ pip install -e sagemaker-ssh-helper[cdk]
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/ec2-user/environment/sagemaker-ssh-helper
  Preparing metadata (setup.py) ... done
Collecting sagemaker>=2.145.0
  Downloading sagemaker-2.228.0-py3-none-any.whl (1.5 MB)
     |████████████████████████████████| 1.5 MB 4.3 MB/s            
Collecting psutil
  Downloading psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (290 kB)
     |████████████████████████████████| 290 kB 28.6 MB/s            
Collecting aws-cdk-lib==2.77.0
  Downloading aws_cdk_lib-2.77.0-py3-none-any.whl (59.8 MB)
     |████████████████████████████████| 59.8 MB 191 kB/s             
Collecting constructs<11.0.0,>=10.0.0
  Downloading constructs-10.3.0-py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 9.9 MB/s             
Collecting jsii<2.0.0,>=1.78.1
  Downloading jsii-1.102.0-py3-none-any.whl (554 kB)
     |████████████████████████████████| 554 kB 33.1 MB/s            
Collecting aws-cdk.asset-kubectl-v20<3.0.0,>=2.1.1
  Downloading aws_cdk.asset_kubectl_v20-2.1.2-py3-none-any.whl (25.4 MB)
     |████████████████████████████████| 25.4 MB 69.8 MB/s            
Collecting publication>=0.0.3
  Downloading publication-0.0.3-py2.py3-none-any.whl (7.7 kB)
Collecting aws-cdk.asset-awscli-v1<3.0.0,>=2.2.97
  Downloading aws_cdk.asset_awscli_v1-2.2.202-py3-none-any.whl (16.2 MB)
     |████████████████████████████████| 16.2 MB 17.5 MB/s            
Collecting aws-cdk.asset-node-proxy-agent-v5<3.0.0,>=2.0.77
  Downloading aws_cdk.asset_node_proxy_agent_v5-2.0.166-py3-none-any.whl (1.3 MB)
     |████████████████████████████████| 1.3 MB 40.2 MB/s            
Collecting typeguard~=2.13.3
  Downloading typeguard-2.13.3-py3-none-any.whl (17 kB)
Collecting PyYAML~=6.0
  Downloading PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (737 kB)
     |████████████████████████████████| 737 kB 43.4 MB/s            
Collecting numpy<2.0,>=1.9.0
  Downloading numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (18.2 MB)
     |████████████████████████████████| 18.2 MB 181 kB/s            
Collecting schema
  Downloading schema-0.7.7-py2.py3-none-any.whl (18 kB)
Collecting tblib<4,>=1.7.0
  Downloading tblib-3.0.0-py3-none-any.whl (12 kB)
Collecting tqdm
  Downloading tqdm-4.66.5-py3-none-any.whl (78 kB)
     |████████████████████████████████| 78 kB 3.4 MB/s             
Collecting smdebug-rulesconfig==1.0.1
  Downloading smdebug_rulesconfig-1.0.1-py2.py3-none-any.whl (20 kB)
Collecting pathos
  Downloading pathos-0.3.2-py3-none-any.whl (82 kB)
     |████████████████████████████████| 82 kB 357 kB/s             
Requirement already satisfied: jsonschema in /usr/lib/python3.9/site-packages (from sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (3.2.0)
Collecting attrs<24,>=23.1.0
  Downloading attrs-23.2.0-py3-none-any.whl (60 kB)
     |████████████████████████████████| 60 kB 10.7 MB/s            
Collecting importlib-metadata<7.0,>=1.4.0
  Downloading importlib_metadata-6.11.0-py3-none-any.whl (23 kB)
Collecting google-pasta
  Downloading google_pasta-0.2.0-py3-none-any.whl (57 kB)
     |████████████████████████████████| 57 kB 9.5 MB/s             
Collecting protobuf<5.0,>=3.12
  Downloading protobuf-4.25.4-cp37-abi3-manylinux2014_x86_64.whl (294 kB)
     |████████████████████████████████| 294 kB 65.5 MB/s            
Requirement already satisfied: packaging>=20.0 in /usr/lib/python3.9/site-packages (from sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (21.3)
Requirement already satisfied: requests in /usr/lib/python3.9/site-packages (from sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (2.25.1)
Collecting pandas
  Downloading pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (13.1 MB)
     |████████████████████████████████| 13.1 MB 56.0 MB/s            
Requirement already satisfied: platformdirs in /usr/local/lib/python3.9/site-packages (from sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (4.2.2)
Collecting boto3<2.0,>=1.34.142
  Downloading boto3-1.34.159-py3-none-any.whl (139 kB)
     |████████████████████████████████| 139 kB 52.2 MB/s            
Collecting urllib3<3.0.0,>=1.26.8
  Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)
     |████████████████████████████████| 121 kB 45.2 MB/s            
Collecting docker
  Downloading docker-7.1.0-py3-none-any.whl (147 kB)
     |████████████████████████████████| 147 kB 42.5 MB/s            
Collecting cloudpickle==2.2.1
  Downloading cloudpickle-2.2.1-py3-none-any.whl (25 kB)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/lib/python3.9/site-packages (from boto3<2.0,>=1.34.142->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (0.10.0)
Collecting botocore<1.35.0,>=1.34.159
  Downloading botocore-1.34.159-py3-none-any.whl (12.5 MB)
     |████████████████████████████████| 12.5 MB 4.0 MB/s             
Collecting s3transfer<0.11.0,>=0.10.0
  Downloading s3transfer-0.10.2-py3-none-any.whl (82 kB)
     |████████████████████████████████| 82 kB 2.3 MB/s             
Collecting zipp>=0.5
  Downloading zipp-3.20.0-py3-none-any.whl (9.4 kB)
Requirement already satisfied: python-dateutil in /usr/lib/python3.9/site-packages (from jsii<2.0.0,>=1.78.1->aws-cdk-lib==2.77.0->sagemaker-ssh-helper==2.2.1.dev1) (2.8.1)
Collecting cattrs<23.3,>=1.8
  Downloading cattrs-23.2.3-py3-none-any.whl (57 kB)
     |████████████████████████████████| 57 kB 8.7 MB/s             
Collecting importlib-resources>=5.2.0
  Downloading importlib_resources-6.4.0-py3-none-any.whl (38 kB)
Requirement already satisfied: typing-extensions<5.0,>=3.8 in /usr/local/lib/python3.9/site-packages (from jsii<2.0.0,>=1.78.1->aws-cdk-lib==2.77.0->sagemaker-ssh-helper==2.2.1.dev1) (4.12.2)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/lib/python3.9/site-packages (from packaging>=20.0->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (2.4.7)
Collecting requests
  Downloading requests-2.32.3-py3-none-any.whl (64 kB)
     |████████████████████████████████| 64 kB 6.9 MB/s             
Collecting charset-normalizer<4,>=2
  Downloading charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (142 kB)
     |████████████████████████████████| 142 kB 17.5 MB/s            
Collecting certifi>=2017.4.17
  Downloading certifi-2024.7.4-py3-none-any.whl (162 kB)
     |████████████████████████████████| 162 kB 21.0 MB/s            
Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3.9/site-packages (from requests->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (2.10)
Requirement already satisfied: six in /usr/lib/python3.9/site-packages (from google-pasta->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (1.15.0)
Requirement already satisfied: pyrsistent>=0.14.0 in /usr/lib64/python3.9/site-packages (from jsonschema->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (0.17.3)
Requirement already satisfied: setuptools in /usr/lib/python3.9/site-packages (from jsonschema->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (59.6.0)
Requirement already satisfied: pytz>=2020.1 in /usr/lib/python3.9/site-packages (from pandas->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (2022.7.1)
Collecting python-dateutil
  Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
     |████████████████████████████████| 229 kB 17.5 MB/s            
Collecting tzdata>=2022.7
  Downloading tzdata-2024.1-py2.py3-none-any.whl (345 kB)
     |████████████████████████████████| 345 kB 71.3 MB/s            
Requirement already satisfied: dill>=0.3.8 in /usr/local/lib/python3.9/site-packages (from pathos->sagemaker>=2.145.0->sagemaker-ssh-helper==2.2.1.dev1) (0.3.8)
Collecting ppft>=1.7.6.8
  Downloading ppft-1.7.6.8-py3-none-any.whl (56 kB)
     |████████████████████████████████| 56 kB 9.2 MB/s             
Collecting multiprocess>=0.70.16
  Downloading multiprocess-0.70.16-py39-none-any.whl (133 kB)
     |████████████████████████████████| 133 kB 61.2 MB/s            
Collecting pox>=0.3.4
  Downloading pox-0.3.4-py3-none-any.whl (29 kB)
Collecting urllib3<3.0.0,>=1.26.8
  Downloading urllib3-1.26.19-py2.py3-none-any.whl (143 kB)
     |████████████████████████████████| 143 kB 43.9 MB/s            
Collecting exceptiongroup>=1.1.1
  Downloading exceptiongroup-1.2.2-py3-none-any.whl (16 kB)
Installing collected packages: urllib3, python-dateutil, zipp, exceptiongroup, charset-normalizer, certifi, botocore, attrs, tzdata, typeguard, s3transfer, requests, publication, ppft, pox, numpy, multiprocess, importlib-resources, cattrs, tqdm, tblib, smdebug-rulesconfig, schema, PyYAML, psutil, protobuf, pathos, pandas, jsii, importlib-metadata, google-pasta, docker, cloudpickle, boto3, sagemaker, constructs, aws-cdk.asset-node-proxy-agent-v5, aws-cdk.asset-kubectl-v20, aws-cdk.asset-awscli-v1, sagemaker-ssh-helper, aws-cdk-lib
  Running setup.py develop for sagemaker-ssh-helper
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
awscli 2.15.30 requires python-dateutil<=2.8.2,>=2.1, but you have python-dateutil 2.9.0.post0 which is incompatible.
Successfully installed PyYAML-6.0.2 attrs-23.2.0 aws-cdk-lib-2.77.0 aws-cdk.asset-awscli-v1-2.2.202 aws-cdk.asset-kubectl-v20-2.1.2 aws-cdk.asset-node-proxy-agent-v5-2.0.166 boto3-1.34.159 botocore-1.34.159 cattrs-23.2.3 certifi-2024.7.4 charset-normalizer-3.3.2 cloudpickle-2.2.1 constructs-10.3.0 docker-7.1.0 exceptiongroup-1.2.2 google-pasta-0.2.0 importlib-metadata-6.11.0 importlib-resources-6.4.0 jsii-1.102.0 multiprocess-0.70.16 numpy-1.26.4 pandas-2.2.2 pathos-0.3.2 pox-0.3.4 ppft-1.7.6.8 protobuf-4.25.4 psutil-6.0.0 publication-0.0.3 python-dateutil-2.9.0.post0 requests-2.32.3 s3transfer-0.10.2 sagemaker-2.228.0 sagemaker-ssh-helper schema-0.7.7 smdebug-rulesconfig-1.0.1 tblib-3.0.0 tqdm-4.66.5 typeguard-2.13.3 tzdata-2024.1 urllib3-1.26.19 zipp-3.20.0
Admin:~/environment $ SAGEMAKER_ROLE_ARN="arn:aws:iam::768431326802:role/service-role/AmazonSageMaker-ExecutionRole-20221201T104186"
Admin:~/environment $ USER_ROLE_ARN="arn:aws:iam::768431326802:role/service-role/AmazonSageMaker-ExecutionRole-20221201T104186"
Admin:~/environment $ ACCOUNT_ID="768431326802"
Admin:~/environment $ REGION="us-west-2"
Admin:~/environment $ cdk bootstrap aws://"$ACCOUNT_ID"/"$REGION"
 ⏳  Bootstrapping environment aws://768431326802/us-west-2...
Trusted accounts for deployment: (none)
Trusted accounts for lookup: (none)
Using default execution policy of 'arn:aws:iam::aws:policy/AdministratorAccess'. Pass '--cloudformation-execution-policies' to customize.
 ✅  Environment aws://768431326802/us-west-2 bootstrapped (no changes).

Admin:~/environment $ APP="python -m sagemaker_ssh_helper.cdk.iam_ssm_app"
Admin:~/environment $ 
Admin:~/environment $ AWS_REGION="$REGION" cdk -a "$APP" deploy SSH-IAM-SSM-Stack \
>   -c sagemaker_role="$SAGEMAKER_ROLE_ARN" \
>   -c user_role="$USER_ROLE_ARN"
/bin/sh: line 1: python: command not found

Subprocess exited with error 127
Admin:~/environment $ alias python=python3
Admin:~/environment $ AWS_REGION="$REGION" cdk -a "$APP" deploy SSH-IAM-SSM-Stack   -c sagemaker_role="$SAGEMAKER_ROLE_ARN"   -c user_role="$USER_ROLE_ARN"
/bin/sh: line 1: python: command not found

Subprocess exited with error 127
Admin:~/environment $ APP="python3 -m sagemaker_ssh_helper.cdk.iam_ssm_app"
Admin:~/environment $ AWS_REGION="$REGION" cdk -a "$APP" deploy SSH-IAM-SSM-Stack   -c sagemaker_role="$SAGEMAKER_ROLE_ARN"   -c user_role="$USER_ROLE_ARN"

✨  Synthesis time: 19.59s

current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-deploy-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-deploy-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
SSH-IAM-SSM-Stack:  start: Building e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d:current_account-current_region
SSH-IAM-SSM-Stack:  success: Built e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d:current_account-current_region
SSH-IAM-SSM-Stack:  start: Building 7a39e218bc37dc687bdbb879b8950f0c28f541610eafac92a5cdc58a6b9249d7:current_account-current_region
SSH-IAM-SSM-Stack:  success: Built 7a39e218bc37dc687bdbb879b8950f0c28f541610eafac92a5cdc58a6b9249d7:current_account-current_region
SSH-IAM-SSM-Stack:  start: Publishing e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d:current_account-current_region
SSH-IAM-SSM-Stack:  start: Publishing 7a39e218bc37dc687bdbb879b8950f0c28f541610eafac92a5cdc58a6b9249d7:current_account-current_region
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-file-publishing-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-file-publishing-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
SSH-IAM-SSM-Stack:  success: Published e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d:current_account-current_region
SSH-IAM-SSM-Stack:  success: Published 7a39e218bc37dc687bdbb879b8950f0c28f541610eafac92a5cdc58a6b9249d7:current_account-current_region
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-lookup-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
Lookup role exists but was not assumed. Proceeding with default credentials.
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-deploy-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
SSH-IAM-SSM-Stack: deploying... [1/1]
SSH-IAM-SSM-Stack: creating CloudFormation changeset...

 ✅  SSH-IAM-SSM-Stack

✨  Deployment time: 82.13s

Stack ARN:
arn:aws:cloudformation:us-west-2:768431326802:stack/SSH-IAM-SSM-Stack/30110640-59a6-11ef-a772-02388a0fb0c9

✨  Total time: 101.72s


Admin:~/environment $ APP="python3 -m sagemaker_ssh_helper.cdk.advanced_tier_app"
Admin:~/environment $ AWS_REGION="$REGION" cdk -a "$APP" deploy SSM-Advanced-Tier-Stack

✨  Synthesis time: 12.27s

current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-deploy-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-deploy-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
SSM-Advanced-Tier-Stack:  start: Building b85574a7447679f637c62d77740251e33d86b9232ec1ad17abcbae3abea2e21b:current_account-current_region
SSM-Advanced-Tier-Stack:  success: Built b85574a7447679f637c62d77740251e33d86b9232ec1ad17abcbae3abea2e21b:current_account-current_region
SSM-Advanced-Tier-Stack:  start: Publishing b85574a7447679f637c62d77740251e33d86b9232ec1ad17abcbae3abea2e21b:current_account-current_region
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-file-publishing-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
SSM-Advanced-Tier-Stack:  success: Published b85574a7447679f637c62d77740251e33d86b9232ec1ad17abcbae3abea2e21b:current_account-current_region
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-lookup-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
Lookup role exists but was not assumed. Proceeding with default credentials.
current credentials could not be used to assume 'arn:aws:iam::768431326802:role/cdk-hnb659fds-deploy-role-768431326802-us-west-2', but are for the right account. Proceeding anyway.
SSM-Advanced-Tier-Stack: deploying... [1/1]
SSM-Advanced-Tier-Stack: creating CloudFormation changeset...

 ✅  SSM-Advanced-Tier-Stack

✨  Deployment time: 82.08s

Stack ARN:
arn:aws:cloudformation:us-west-2:768431326802:stack/SSM-Advanced-Tier-Stack/1d56c110-59a7-11ef-b551-02fba6bbb051

✨  Total time: 94.34s
```
